### PR TITLE
service_name is expected instead of name

### DIFF
--- a/examples/complete-mongo/README.md
+++ b/examples/complete-mongo/README.md
@@ -13,7 +13,7 @@ data "ibm_resource_group" "resource_group" {
 module "database_mongo" {
   source                               = "../../modules/mongo"
   resource_group_id                    = data.ibm_resource_group.resource_group.id
-  name                                 = var.name
+  service_name                         = var.name
   plan                                 = var.plan
   location                             = var.location
   adminpassword                        = var.adminpassword


### PR DESCRIPTION
Otherwise you face this error
Error: Unsupported argument
│
│   on main.tf line 176, in module "database_mongo":
│  176:   name                                 = var.icd_mongo_name
│
│ An argument named "name" is not expected here.